### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  main:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: build
+          key: ${{ runner.os }}-build
+
+      - name: Install Packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes  \
+                  libcurl4-gnutls-dev \
+                  libxerces-c-dev
+
+      - name: Build
+        run: |
+          cmake -B build -DTEST=1
+          cmake --build build -j$(nproc)
+
+      - name: Test
+        run: ./testoadr
+        working-directory: build


### PR DESCRIPTION
Add a simple GitHub Actions Workflow for building and testing the library. I think we don't need the Docker at this point, and without the Docker, the build pipeline will be much simpler.