### PR TITLE
Add ccache compiler cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [master]
+    branches:
+      - master
   workflow_dispatch:
 
 jobs:
@@ -13,13 +14,15 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         with:
-          path: build
-          key: ${{ runner.os }}-build
+          path: ~/.ccache
+          key: ${{ runner.os }}-ccache-${{ github.run_number }}
+          restore-keys: ${{ runner.os }}-ccache-
 
       - name: Install Packages
         run: |
           sudo apt-get update
           sudo apt-get install --yes  \
+                  ccache \
                   libcurl4-gnutls-dev \
                   libxerces-c-dev
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,12 @@ set(LIBOADR_MINOR_VERSION 0)
 set(LIBOADR_MICRO_VERSION 0)
 set(LIBOADR_VERSION ${LIBOADR_MAJOR_VERSION}.${LIBOADR_MINOR_VERSION}.${LIBOADR_MICRO_VERSION})
 
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  set(CMAKE_C_COMPILER_LAUNCHER   ${CCACHE_PROGRAM})
+  set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
+endif()
+
 # Library notes:
 # apt-get install libxerces-c-dev
 # apt-get install libcurl4-gnutls-dev
@@ -63,7 +69,6 @@ if (SAMPLE)
 endif()
 
 if (TEST)
-  
   add_subdirectory(googletest-release-1.7.0)
 
   include_directories(googletest-release-1.7.0/include)
@@ -73,11 +78,10 @@ if (TEST)
   # file(COPY )
   file(REMOVE_RECURSE ./xml)
   file(COPY ./oadrtest/oadrtest DESTINATION ./xml FILES_MATCHING PATTERN "*.xml" PATTERN "*.txt")
-  
+
   # ---- tests ----
   file(GLOB_RECURSE oadrtest_SRC ./oadrtest/oadrtest/*.cpp)
   add_executable(testoadr ${oadrtest_SRC})
   target_link_libraries (testoadr LINK_PUBLIC oadr oadrsd curl xerces-c gtest pthread)
-
 endif()
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,27 @@ Copyright (c) 2016, Electric Power Research Institute (EPRI)
 This project (OADRLIB) provides a basis for implementing an OpenADR2.0b VEN.  Http pull is the only supported transport.
 
 # Dependencies
-The library has the following dependencies:
-  * GTest (unit testing, source is inlcuded)  
-  * code synthesis XSD 4.0.0 (included in the project)
-  * curl (http/s communication) + any curl supported SSL library
 
-Follow the instructions for your operating system to install `curl` and a curl
-supported SSL library.
+The library is built and tested on Ubuntu Linux 20.04.
 
-The library is built and tested on Ubuntu Linux 16.04.
+```
+apt-get update
+apt-get install --yes   \
+   libcurl4-gnutls-dev  \
+   libxerces-c-dev
+```
+
+# Compiler Cache
+
+The project can use `ccache` in order to improve (re)compilation time. The `ccache` package is
+provided by Ubuntu Linux distribution:
+
+```
+apt-get install --yes ccache
+```
+
+After the first compilation (see the next paragraph), the compiler cache is saved to `~/.ccache`
+directory.
 
 # Build Instructions
 OADRLIB uses cmake.  Here are general instructions for starting the build:


### PR DESCRIPTION
The [ccache](https://ccache.dev) is a compiler caching tool. It speeds up recompilation by caching
previous compilations and detecting when the same compilation is being done again