### PR TITLE
Expose configuration for register retry interval

### DIFF
--- a/oadr/oadr/manager/VENManager.h
+++ b/oadr/oadr/manager/VENManager.h
@@ -35,27 +35,28 @@
 class VENManager : public ISendCreatedEvent, public ISendReport, public IVENManager
 {
 private:
-	unique_ptr<VEN2b> m_ven;
-	unique_ptr<Scheduler> m_scheduler;
-	unique_ptr<EventManager> m_eventManager;
-	unique_ptr<ReportManager> m_reportManager;
+	std::unique_ptr<VEN2b> m_ven;
+	std::unique_ptr<Scheduler> m_scheduler;
+	std::unique_ptr<EventManager> m_eventManager;
+	std::unique_ptr<ReportManager> m_reportManager;
 
 	IReportService *m_reportService;
 
 	IOADRExceptionService *m_exceptionService;
 
-    condition_variable m_condition;
-    mutex m_mutex;
+    std::condition_variable m_condition;
+    std::mutex m_mutex;
+    std::chrono::seconds m_registerRetryInterval;
 
 	bool m_shutdown;
 
-	virtual void sendCreatedEvent(string responseCode, string responseDescription, string requestID, oadr2b::ei::eventResponses::eventResponse_sequence &eventResponses);
+	virtual void sendCreatedEvent(std::string responseCode, std::string responseDescription, std::string requestID, oadr2b::ei::eventResponses::eventResponse_sequence &eventResponses);
 
-	virtual void sendUpdateReport(oadrUpdateReportType::oadrReport_sequence &sequence, time_t dtstart, string reportRequestID, time_t createdDateTime);
-	virtual void sendCreatedReport(const set<string> &pendingReports, string requestID, string responseCode, string responseDescription);
-	virtual void sendCanceledReport(const set<string> &pendingReports, string requestID, string responseCode, string responseDescription);
+	virtual void sendUpdateReport(oadrUpdateReportType::oadrReport_sequence &sequence, time_t dtstart, std::string reportRequestID, time_t createdDateTime);
+	virtual void sendCreatedReport(const std::set<std::string> &pendingReports, std::string requestID, std::string responseCode, std::string responseDescription);
+	virtual void sendCanceledReport(const std::set<std::string> &pendingReports, std::string requestID, std::string responseCode, std::string responseDescription);
 
-	VENManager(unique_ptr<VEN2b> ven, IEventService *eventService, IReportService *reportService, IOADRExceptionService *exceptionService);
+	VENManager(std::unique_ptr<VEN2b> ven, IEventService *eventService, IReportService *reportService, IOADRExceptionService *exceptionService, std::chrono::seconds registerRetryInterval);
 
 	void exceptionWait();
 

--- a/oadr/oadr/manager/VENManagerConfig.cpp
+++ b/oadr/oadr/manager/VENManagerConfig.cpp
@@ -1,0 +1,49 @@
+/*
+ * VENManagerConfig.cpp
+ *
+ *  Created on: Feb 22, 2021
+ *      Author: Michał Kowalczyk
+ */
+
+
+#include "../manager/VENManagerConfig.h"
+
+#include <curl/curl.h>
+
+#include "../ven/IOadrMessage.h"
+
+ttls::ttls() :
+	useTls(false),
+	privateKeyPath(),
+	caBundlePath(),
+	verifyHostname(true),
+	cipherList("AES128-SHA256:ECDHE-ECDSA-AES128-SHA256"),
+	sslVersion(CURL_SSLVERSION_TLSv1_2)
+{
+}
+
+tservices::tservices() :
+	eventService(nullptr),
+	reportService(nullptr),
+	exceptionService(nullptr),
+	oadrMessage(&OadrMessageBlank::oadrMessageBlank)
+{
+}
+
+ttimeouts::ttimeouts() :
+	connectTimeout(120),
+	requestTimeout(30)
+{
+}
+
+VENManagerConfig::VENManagerConfig() :
+	vtnURL(),
+	venName(),
+	venID(),
+	registrationID(),
+	tls(),
+	services(),
+	timeouts(),
+	registerRetryInterval(10)
+{
+}

--- a/oadr/oadr/manager/VENManagerConfig.h
+++ b/oadr/oadr/manager/VENManagerConfig.h
@@ -8,16 +8,13 @@
 #ifndef OADR_OADR_MANAGER_VENMANAGERCONFIG_H_
 #define OADR_OADR_MANAGER_VENMANAGERCONFIG_H_
 
+#include <chrono>
 #include <string>
 
-// TODO: needed for TLS default version
-// remove reliance on curl
-#include <curl/curl.h>
-
-#include "eventmanager/IEventService.h"
-#include "reportmanager/IReportService.h"
-#include "IOADRExceptionService.h"
-#include "../ven/IOadrMessage.h"
+class IEventService;
+class IReportService;
+class IOADRExceptionService;
+class IOadrMessage;
 
 struct ttls
 {
@@ -29,6 +26,8 @@ struct ttls
 	bool verifyHostname;
 	std::string cipherList;
 	long sslVersion;
+
+	ttls();
 };
 
 struct tservices
@@ -37,12 +36,16 @@ struct tservices
 	IReportService *reportService;
 	IOADRExceptionService *exceptionService;
 	IOadrMessage *oadrMessage;
+
+	tservices();
 };
 
 struct ttimeouts
 {
 	unsigned int connectTimeout;
 	unsigned int requestTimeout;
+
+	ttimeouts();
 };
 
 struct VENManagerConfig
@@ -58,21 +61,9 @@ struct VENManagerConfig
 
 	ttimeouts timeouts;
 
-	VENManagerConfig()
-	{
-		tls.useTls = false;
-		tls.verifyHostname = true;
-		tls.cipherList = "AES128-SHA256:ECDHE-ECDSA-AES128-SHA256";
-		tls.sslVersion = CURL_SSLVERSION_TLSv1_2;
+	std::chrono::seconds registerRetryInterval;
 
-		services.eventService = NULL;
-		services.reportService = NULL;
-		services.exceptionService = NULL;
-		services.oadrMessage = &OadrMessageBlank::oadrMessageBlank;
-
-		timeouts.connectTimeout = 120;
-		timeouts.requestTimeout = 30;
-	};
+	VENManagerConfig();
 };
 
 #endif /* OADR_OADR_MANAGER_VENMANAGERCONFIG_H_ */


### PR DESCRIPTION
I exposed a field to configure register retry interval, so that the client can decide how much time it should wait if a register party was not successful.

Also, I:
- cleaned up a bit VENManagerConfig (solved one TODO),
- added namespace to variables in touched header files so it will be easier to remove using directives from other header files.