### PR TITLE
Expose exception retry interval

### DIFF
--- a/oadr/oadr/manager/VENManager.cpp
+++ b/oadr/oadr/manager/VENManager.cpp
@@ -7,11 +7,12 @@
 
 #include "../manager/VENManager.h"
 
-VENManager::VENManager(unique_ptr<VEN2b> ven, IEventService *eventService, IReportService *reportService, IOADRExceptionService *exceptionService, seconds registerRetryInterval) :
+VENManager::VENManager(unique_ptr<VEN2b> ven, IEventService *eventService, IReportService *reportService, IOADRExceptionService *exceptionService, seconds registerRetryInterval, seconds exceptionRetryInterval) :
 	m_ven(std::move(ven)),
 	m_reportService(reportService),
 	m_exceptionService(exceptionService),
-	m_registerRetryInterval(registerRetryInterval)
+	m_registerRetryInterval(registerRetryInterval),
+	m_exceptionRetryInterval(exceptionRetryInterval)
 {
 	m_scheduler = unique_ptr<Scheduler>(new Scheduler());
 
@@ -94,7 +95,8 @@ IVENManager *VENManager::init(VENManagerConfig &config)
 			config.services.eventService,
 			config.services.reportService,
 			config.services.exceptionService,
-			config.registerRetryInterval);
+			config.registerRetryInterval,
+			config.exceptionRetryInterval);
 
 	return venManager;
 }

--- a/oadr/oadr/manager/VENManager.cpp
+++ b/oadr/oadr/manager/VENManager.cpp
@@ -107,7 +107,7 @@ void VENManager::exceptionWait()
 {
 	std::unique_lock<std::mutex> lock(m_mutex);
 
-	m_condition.wait_for(lock, seconds(10));
+	m_condition.wait_for(lock, seconds(m_exceptionRetryInterval));
 }
 
 /********************************************************************************/

--- a/oadr/oadr/manager/VENManager.h
+++ b/oadr/oadr/manager/VENManager.h
@@ -47,6 +47,7 @@ private:
     std::condition_variable m_condition;
     std::mutex m_mutex;
     std::chrono::seconds m_registerRetryInterval;
+    std::chrono::seconds m_exceptionRetryInterval;
 
 	bool m_shutdown;
 
@@ -56,7 +57,12 @@ private:
 	virtual void sendCreatedReport(const std::set<std::string> &pendingReports, std::string requestID, std::string responseCode, std::string responseDescription);
 	virtual void sendCanceledReport(const std::set<std::string> &pendingReports, std::string requestID, std::string responseCode, std::string responseDescription);
 
-	VENManager(std::unique_ptr<VEN2b> ven, IEventService *eventService, IReportService *reportService, IOADRExceptionService *exceptionService, std::chrono::seconds registerRetryInterval);
+	VENManager(std::unique_ptr<VEN2b> ven,
+	           IEventService *eventService,
+	           IReportService *reportService,
+	           IOADRExceptionService *exceptionService,
+	           std::chrono::seconds registerRetryInterval,
+	           std::chrono::seconds exceptionRetryInterval);
 
 	void exceptionWait();
 

--- a/oadr/oadr/manager/VENManagerConfig.cpp
+++ b/oadr/oadr/manager/VENManagerConfig.cpp
@@ -44,6 +44,7 @@ VENManagerConfig::VENManagerConfig() :
 	tls(),
 	services(),
 	timeouts(),
-	registerRetryInterval(10)
+	registerRetryInterval(10),
+	exceptionRetryInterval(10)
 {
 }

--- a/oadr/oadr/manager/VENManagerConfig.h
+++ b/oadr/oadr/manager/VENManagerConfig.h
@@ -62,6 +62,7 @@ struct VENManagerConfig
 	ttimeouts timeouts;
 
 	std::chrono::seconds registerRetryInterval;
+	std::chrono::seconds exceptionRetryInterval;
 
 	VENManagerConfig();
 };


### PR DESCRIPTION
While register retry interval allows gives some control over waiting time around register party, sometimes the reason for retrial is an exception thrown. This change allows to configure interval of retry due to an exception situation.